### PR TITLE
Bug fix for Node web server

### DIFF
--- a/web.js
+++ b/web.js
@@ -1,10 +1,10 @@
 var express = require('express');
 var app = express.createServer(express.logger());
 var fs = require('fs');
-var buf = new Buffer(fs.readFileSync('index.html'));
+var indexHtml = fs.readFileSync('index.html', 'utf8');
 
 app.get('/', function(request, response) {
-  response.send(buf.toString());
+  response.send(indexHtml);
 });
 
 var port = process.env.PORT || 8080;


### PR DESCRIPTION
## Summary
- remove deprecated Buffer usage when reading `index.html`

## Testing
- `node web.js`

------
https://chatgpt.com/codex/tasks/task_e_68482824e0ec832baa19135d3320891a