### PR TITLE
Fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
         </div>
         <div class="span5 copy">
           <p>
-            Are you feeling uncomfortably being abroad, visiting foreign counties and trying to read signs on languages you don&#39t know and can&#39t understand? Are you feeling lost in new city and missed many interesting places and new experience there? Only that you need now to install new Traveler application for Google Glass and enjoy being everywhere across the globe feeling very much at home. Improved geolocation, text recognition and language autodetection from your Glass - everything what you need being in new place.
+            Are you feeling uncomfortably being abroad, visiting foreign countries and trying to read signs on languages you don&#39t know and can&#39t understand? Are you feeling lost in new city and missed many interesting places and new experience there? Only that you need now to install new Traveler application for Google Glass and enjoy being everywhere across the globe feeling very much at home. Improved geolocation, text recognition and language autodetection from your Glass - everything what you need being in new place.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix a marketing typo in `index.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68482bb7ad60832b965ac6b6085a2689