### PR TITLE
Fix typo, CSS bug, comment, and add tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
        .linediv-r {
          border-left: 1px white solid;
        }
+       .linediv-c {
+         border-left: 1px white solid;
+         border-right: 1px white solid;
+       }
       }
 
       /* Landscape phones and down */
@@ -37,6 +41,10 @@
        }
        .linediv-r {
          border-top: 1px white solid;
+       }
+       .linediv-c {
+         border-top: 1px white solid;
+         border-bottom: 1px white solid;
        }
       }
 
@@ -172,7 +180,7 @@
           <div class="span8 offset2">
             <div class="row-fluid statistics">
               <div class="span4">
-                <!-- linediv-l and linediv-r give dividing lines that look
+                <!-- linediv-l, linediv-c, and linediv-r give dividing lines that look
                 different in horizontal and vertical layouts, illustrating
                 media queries. -->
                 <div class="linediv-l">
@@ -245,7 +253,7 @@
         </div>
         <div class="span5 copy">
           <p>
-            Are you feeling uncomfortable being abroad, visiting foreign countries and trying to read signs on languages you don&#39t know and can&#39t understand? Are you feeling lost in new city and missed many interesting places and new experience there? Only that you need now to install new Traveler application for Google Glass and enjoy being everywhere across the globe feeling very much at home. Improved geolocation, text recognition and language autodetection from your Glass - everything you need being in new place.
+            Are you feeling uncomfortable being abroad, visiting foreign countries and trying to read signs on languages you don&#39t know and can&#39t understand? Are you feeling lost in new city and missed many interesting places and new experience there? All you need now is to install the new Traveler application for Google Glass and enjoy being everywhere across the globe feeling very much at home. Improved geolocation, text recognition and language autodetection from your Glass - everything you need being in new place.
           </p>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
   "engines": {
     "node": "0.8.x",
     "npm": "1.1.x"
+  },
+  "scripts": {
+    "test": "node test/graderTest.js"
   }
 }
+


### PR DESCRIPTION
## Summary
- fix traveler marketing text typo
- style `.linediv-c` for both large and small layouts
- document `.linediv-c` in statistics section comment
- add test script to `package.json`

## Testing
- `npm test` *(fails: Cannot find module 'commander')*

------
https://chatgpt.com/codex/tasks/task_e_68484b857f00832bb3b03b8837da68e6