### PR TITLE
Initialize Doggo Network skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-tmp.html
+node_modules/
+frontend/node_modules/
+backend/__pycache__/
+*.pyc
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-# Bitstarter
+# Doggo Network
 
-This project requires some Node.js dependencies. Before running the tests, install them with:
+Doggo Network is a mobile-first social network for dog owners. The project is split into a React + TypeScript front-end and a Flask back-end using PostgreSQL. This repository contains a basic starting point for development.
 
-```bash
-npm install
+## Structure
+
+```
+frontend/   - React application configured with Tailwind CSS
+backend/    - Flask API with SQLAlchemy models
 ```
 
-This will install packages listed in `package.json`, including `commander`, `cheerio`, and `restler` which are used by `grader.js`.
+## Getting Started
 
-After installing dependencies, run the test suite with:
+1. Install Node.js dependencies in `frontend/` and Python dependencies in `backend/`.
+2. Configure a PostgreSQL database and set the `DATABASE_URL` environment variable for the backend.
+3. Run the front-end with `npm run dev` and the backend with `python run.py`.
 
-```bash
-npm test
-```
+The initial implementation exposes a placeholder API and a simple landing page. Expand the models and routes to add user profiles, posts, comments, following, and notifications.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+# Doggo Network Backend
+
+This directory contains a minimal Flask backend configured for PostgreSQL via SQLAlchemy.
+
+## Quick Start
+
+1. Create a virtual environment and install dependencies from `requirements.txt`.
+2. Set the `DATABASE_URL` environment variable to point to your PostgreSQL instance.
+3. Run `python run.py` to start the API server.
+
+The backend exposes a simple `/` endpoint and includes basic models for users, dogs, and posts.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+import os
+
+
+db = SQLAlchemy()
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = (
+        os.getenv('DATABASE_URL', 'postgresql://localhost/doggo_network')
+    )
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    db.init_app(app)
+
+    from . import routes
+    app.register_blueprint(routes.bp)
+
+    return app

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,18 @@
+from . import db
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    dogs = db.relationship('Dog', backref='owner', lazy=True)
+
+class Dog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    breed = db.Column(db.String(120))
+    owner_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+
+class Post(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    content = db.Column(db.Text)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,0 +1,7 @@
+from flask import Blueprint, jsonify
+
+bp = Blueprint('api', __name__)
+
+@bp.route('/')
+def index():
+    return jsonify({"message": "Doggo Network API"})

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask-SQLAlchemy
+psycopg2-binary

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,0 +1,7 @@
+from app import create_app
+
+def test_index():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,10 @@
+# Doggo Network Frontend
+
+This directory contains the React + TypeScript front-end for **Doggo Network**. The UI is built with Tailwind CSS and configured using Vite.
+
+## Available Scripts
+
+- `npm run dev` – start a development server with hot reload.
+- `npm run build` – build the production bundle.
+
+Install dependencies with `npm install` (requires Node.js) then run the desired script.

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "doggo-network-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "tailwindcss": "^3.0.0",
+    "postcss": "^8.0.0",
+    "autoprefixer": "^10.0.0"
+    "@testing-library/jest-dom": "^5.16.0",
+    "@testing-library/react": "^13.0.0",
+    "@types/jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "jest": "^29.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Doggo Network</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import App from './App';
+
+test('renders welcome message', () => {
+  const { getByText } = render(<App />);
+  expect(getByText(/Doggo Network/i)).toBeInTheDocument();
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div className="min-h-screen p-4">
+      <h1 className="text-2xl font-bold text-center">Doggo Network</h1>
+      <p className="text-center text-gray-600">Welcome to the dog owner social network!</p>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,ts,jsx,tsx,html}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- bootstrap a new mobile-first social network project called **Doggo Network**
- create React + TypeScript frontend with Tailwind CSS using Vite
- add Flask backend with PostgreSQL configuration and basic models
- document setup steps for frontend and backend

## Testing
- `npm test` *(fails: missing dependencies)*
- `pytest backend/tests/test_routes.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6848606765c0832b8a665be7ea731b2b